### PR TITLE
add default array=[] to chunk(), compact(), concat()

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ $ node ex2.js
 _.compact([0, 1, false, 2, '', 3])=[ 1, 2, 3 ]
 ```
 
+File : ex3.js
+
+```js
+const _ = require('ccclodash')
+
+var array = [1]
+console.log("_.concat(array, 2, [3], [[4]])=",  _.concat(array, 2, [3], [[4]]))
+```
+
+Run
+
+```
+$ node ex3.js
+_.concat(array, 2, [3], [[4]])= [1, 2, [3], [[4]]]
+```
+
 ## Test
 
 ```

--- a/lib/chunk.js
+++ b/lib/chunk.js
@@ -18,7 +18,7 @@
  * // => [['a', 'b', 'c'], ['d']]
  */
 
-function chunk (array, n) {
+function chunk (array = [], n) {
   const clist = []
   for (let i = 0; i < array.length; i += n) {
     clist.push(array.slice(i, i + n))

--- a/lib/compact.js
+++ b/lib/compact.js
@@ -12,7 +12,7 @@
  * _.compact([0, 1, false, 2, '', 3])
  * // => [1, 2, 3]
  */
-function compact (array) {
+function compact (array = []) {
   const clist = []
   for (let o of array) {
     if (o) clist.push(o)

--- a/lib/concat.js
+++ b/lib/concat.js
@@ -10,7 +10,7 @@
  * _.concat([1], 2, [3], [[4]]); 
  * // => [1, 2, [3], [[4]]
  */
-function concat () {
+function concat (array = []) {
   const clist = arguments[0].slice(0)
   for (let i = 1; i < arguments.length; i++) {
     clist.push(arguments[i])


### PR DESCRIPTION
add the example of _.concat(array, ...)